### PR TITLE
iOS 8 fix (depreciated method)

### DIFF
--- a/src/ios/PickContact.m
+++ b/src/ios/PickContact.m
@@ -13,9 +13,11 @@
 }
 
 - (BOOL)peoplePickerNavigationController:(ABPeoplePickerNavigationController*)peoplePicker
-      shouldContinueAfterSelectingPerson:(ABRecordRef)person
+                         shouldContinueAfterSelectingPerson:(ABRecordRef)person
                                 property:(ABPropertyID)property
                               identifier:(ABMultiValueIdentifier)identifier
+
+
 {
     if (kABPersonPhoneProperty == property)
     {
@@ -55,6 +57,16 @@
     [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                                               messageAsString:@"PickContact abort"]
                                             toErrorCallbackString:self.callbackID]];
+}
+
+
+//ios 8 support
+- (void)peoplePickerNavigationController:(ABPeoplePickerNavigationController*)peoplePicker
+    didSelectPerson:(ABRecordRef)person
+    property:(ABPropertyID)property
+    identifier:(ABMultiValueIdentifier)identifier {
+
+[self peoplePickerNavigationController:peoplePicker shouldContinueAfterSelectingPerson:person property:property identifier:identifier];
 }
 
 @end


### PR DESCRIPTION
Updated for iOS 8

Disclaimer:
I'm a web developer first & foremost (no experience with obj-c).  I was able to mess around for a bit and make this work.
- see depreciated statements
  https://developer.apple.com/library/ios/documentation/AddressBookUI/Reference/ABPeoplePickerNavigationControllerDelegate_Protocol/index.html#//apple_ref/occ/intfm/ABPeoplePickerNavigationControllerDelegate/peoplePickerNavigationController:shouldContinueAfterSelectingPerson:property:identifier:
